### PR TITLE
DOP-743 CI: Optional release creation

### DIFF
--- a/docker-build-and-push/action.yml
+++ b/docker-build-and-push/action.yml
@@ -16,6 +16,13 @@ inputs:
       Rarely, then, we can prevent that happening.
     required: false
     default: false
+  suppress-release:
+    description: >
+      By default, this action cuts a release with the build log.
+      Some consumers may prefer to cut their own releases,
+      it which case, set this to true
+    required: false
+    default: false
 
 
 runs:
@@ -104,6 +111,7 @@ runs:
       done
 
   - name: Create Release
+    if: ${{ !inputs.suppress_release }}
     uses: softprops/action-gh-release@v1
     with:
       body_path: BUILDLOG.txt


### PR DESCRIPTION
## Description of the change

Some projects prefer to manually write release notes and cut their own releases.
This allows them to suppress the automatic release.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [x] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
