### PR TITLE
DOP-759 GHA: Update github runner

### DIFF
--- a/launch-self-hosted-runner/action.sh
+++ b/launch-self-hosted-runner/action.sh
@@ -54,6 +54,7 @@ function start_vm {
   else
     echo "✅ Startup script will install GitHub Actions"
     cat <<EOS >>$startup_script
+cat /etc/group
 addgroup google-sudoers
 adduser runner
 echo runner >> /etc/at.allow

--- a/launch-self-hosted-runner/action.sh
+++ b/launch-self-hosted-runner/action.sh
@@ -54,6 +54,7 @@ function start_vm {
   else
     echo "✅ Startup script will install GitHub Actions"
     cat <<EOS >>$startup_script
+addgroup google-sudoers
 adduser runner
 echo runner >> /etc/at.allow
 usermod -aG google-sudoers runner

--- a/launch-self-hosted-runner/action.yml
+++ b/launch-self-hosted-runner/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: true
   runner_ver:
     description: Version of the GitHub Runner.
-    default: "2.291.1"
+    default: "2.294.0"
     required: true
   runner_label:
     description: Extra label to add for the Runner


### PR DESCRIPTION
## Description of the change

Attempting to fix GHA failure in prod.
Adding the google-sudoers group should be superfluous,
but it won't hurt.

- Update GH runner version to 2.294.0
- Add group for google-sudoers

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
