### PR TITLE
DOP-837 Vanta labels for self-hosted runners

### DIFF
--- a/launch-self-hosted-runner/action.sh
+++ b/launch-self-hosted-runner/action.sh
@@ -103,7 +103,7 @@ EOS
     ${image_flag} \
     ${image_family_flag} \
     ${preemptible_flag} \
-    --labels=gh_ready=0 \
+    --labels=gh_ready=0,vanta-description=kubernetes-cluster-node,vanta-owner=judson_dot_lester \
     --metadata-from-file=startup-script="$startup_script"
   echo "::set-output name=label::${VM_ID}"
 


### PR DESCRIPTION
## Description of the change

Add Vanta labels to VMs created for GHA self hosted runners.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [x] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
