### PR TITLE
DOP-1185 Update nix tools

### DIFF
--- a/nix-shell-docker/action.yml
+++ b/nix-shell-docker/action.yml
@@ -31,15 +31,11 @@ runs:
   - name: Install Nix
     env:
       USER: runner
-    uses: cachix/install-nix-action@v21
+    uses: cachix/install-nix-action@v22
     with:
       nix_path: nixpkgs=channel:nixos-unstable
 
-  - name: Setup Cachix
-    uses: cachix/cachix-action@v12
-    with:
-      name: ymeadows-build-tools
-      extraPullNames: nix-community
+  - uses: DeterminateSystems/magic-nix-cache-action@main
 
   - name: Export nix-shell
     shell: bash


### PR DESCRIPTION
## Description of the change

Update Nix installer for GHA to v22.
Switch to DS/magic-cache

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
