### PR TITLE
DOP-1452 Update self hosted runner

### DIFF
--- a/launch-self-hosted-runner/action.yml
+++ b/launch-self-hosted-runner/action.yml
@@ -101,7 +101,8 @@ runs:
     - id: compose-version-candidates
       shell: bash
       run: |
-        echo "2.311.0" > candidate-versions
+        echo "2.316.1" > candidate-versions
+        curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r .tag_name | sed 's/^v//' >> candidate-versions
         echo ${{ inputs.runner_ver }} >> candidate-versions
     - id: highest-runner-version
       uses: ymeadows/versiontool@v1


### PR DESCRIPTION
## Description of the change

Fetches the latest version of the action runner, so that we can stop chasing GH updates

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
