### PR TITLE
DOP-1603 Automatically update nix hashes

### DIFF
--- a/nix-shell-docker/action.yml
+++ b/nix-shell-docker/action.yml
@@ -31,11 +31,17 @@ runs:
   - name: Install Nix
     env:
       USER: runner
-    uses: cachix/install-nix-action@v22
+    uses: cachix/install-nix-action@v30
     with:
       nix_path: nixpkgs=channel:nixos-unstable
 
   - uses: DeterminateSystems/magic-nix-cache-action@main
+
+  - name: Install tools
+    uses: yaxitech/nix-install-pkgs-action@v3
+    with:
+      packages: "gzip,trivy"
+      inputs-from: nixpkgs
 
   - name: Export nix-shell
     shell: bash

--- a/update-flakes/action.yml
+++ b/update-flakes/action.yml
@@ -7,15 +7,38 @@ inputs:
   update_app_key:
     description: Key for the update app; try secrets.DEP_UPDATE_KEY
     required: true
-
+  packages:
+    description: 'A space-separated list of inputs to update. Leave empty to update all inputs.'
+    required: false
+    default: ''
+  blacklist:
+    description: 'A list of dependencies, comma separated, to skip from updating.'
+    required: false
+    default: ''
+  version:
+    description: "How to handle package versions; c.f. the nix-update tool"
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
   - name: Install Nix
-    uses: cachix/install-nix-action@v21
+    uses: cachix/install-nix-action@v30
     with:
       extra_nix_config: |
         access-tokens = github.com=${{ github.token }}
+  - name: Install tools
+    uses: yaxitech/nix-install-pkgs-action@v3
+    with:
+      packages: "nix-update,jq"
+      inputs-from: nixpkgs
+  - name: Run nix-update
+    run: $GITHUB_ACTION_PATH/nix-update.sh
+    shell: bash
+    env:
+      PACKAGES: ${{ inputs.packages }}
+      BLACKLIST: ${{ inputs.blacklist }}
+      VERSION: ${{ inputs.version }}
   - name: Get Updater Token
     uses: tibdex/github-app-token@v1
     id: generate-token
@@ -23,10 +46,9 @@ runs:
       app_id: ${{ inputs.update_app_id}}
       private_key: ${{inputs.update_app_key}}
   - name: Update flake.lock
-    uses: nyarly/update-flake-lock@main # Open PR against upstream
+    uses: DeterminateSystems/update-flake-lock@v24 # Open PR against upstream
     with:
       token: ${{ steps.generate-token.outputs.token }}
-      commit-with-token: true
       pr-title: "Update flake.lock" # Title of PR to be created
       pr-labels: |                  # Labels to be set on the PR
         dependencies
@@ -36,3 +58,4 @@ runs:
         ```
         {{ env.GIT_COMMIT_MESSAGE }}
         ```
+  -  name: Update versions

--- a/update-flakes/nix-update.sh
+++ b/update-flakes/nix-update.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# XXX Borrowed from https://github.com/selfuryon/nix-update-action
+
+set -euo pipefail
+
+enterFlakeFolder() {
+  if [[ -n "$PATH_TO_FLAKE_DIR" ]]; then
+    cd "$PATH_TO_FLAKE_DIR"
+  fi
+}
+
+sanitizeInputs() {
+  # remove all whitespace
+  PACKAGES="${PACKAGES// /}"
+  BLACKLIST="${BLACKLIST// /}"
+}
+
+determinePackages() {
+  # determine packages to update
+  if [[ -z "$PACKAGES" ]]; then
+    PACKAGES=$(nix flake show --json | jq -r '[.packages[] | keys[]] | sort | unique |  join(",")')
+  fi
+}
+
+updatePackages() {
+  if [[ -z "$PACKAGES" ]]; then
+    echo "No packages to update! Exiting."
+    exit 0
+  fi
+  # update packages
+  for PACKAGE in ${PACKAGES//,/ }; do
+    if [[ ",$BLACKLIST," == *",$PACKAGE,"* ]]; then
+        echo "Package '$PACKAGE' is blacklisted, skipping."
+        continue
+    fi
+    echo "Updating package '$PACKAGE'."
+    nix-update --flake ${VERSION:+--version=$VERSION} "$PACKAGE"
+  done
+}
+
+enterFlakeFolder
+sanitizeInputs
+determinePackages
+updatePackages


### PR DESCRIPTION
## Description of the change

Nix uses sha256 hashes of various sources as an integrity check for builds. This is good, generally, but e.g. after a dependabot PR, it can be a hassle to update the hashes. This adds the hash update to the flake.lock update action.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [x] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
