### PR TITLE
DOP-1613 GHA: Revert to forked flake update

### DIFF
--- a/update-flakes/action.yml
+++ b/update-flakes/action.yml
@@ -48,7 +48,7 @@ runs:
       app_id: ${{ inputs.update_app_id}}
       private_key: ${{inputs.update_app_key}}
   - name: Update flake.lock
-    uses: DeterminateSystems/update-flake-lock@v24 # Open PR against upstream
+    uses: nyarly/update-flake-lock@main
     with:
       token: ${{ steps.generate-token.outputs.token }}
       pr-title: "Auto-update flake.lock" # Title of PR to be created


### PR DESCRIPTION
## Description of the change

Upstream doesn't use the token to make commits, which breaks our workflow.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
