### PR TITLE
DOP-1618 GHA: Switch to cachix

### DIFF
--- a/nix-shell-docker/action.yml
+++ b/nix-shell-docker/action.yml
@@ -35,7 +35,12 @@ runs:
     with:
       nix_path: nixpkgs=channel:nixos-unstable
 
-  - uses: DeterminateSystems/magic-nix-cache-action@main
+  - name: Setup Cachix
+    uses: cachix/cachix-action@v16
+    with:
+      name: ymeadows-build-tools
+      authToken: ${{secrets.CACHIX_AUTH_TOKEN }}
+      extraPullNames: nix-community
 
   - name: Install tools
     uses: yaxitech/nix-install-pkgs-action@v3


### PR DESCRIPTION
Determinate's "magic nix cache" stopped working in February

## Description of the change


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
