### PR TITLE
DOP-1624 GHA: Custom actions can only use inputs

### DIFF
--- a/nix-shell-docker/action.yml
+++ b/nix-shell-docker/action.yml
@@ -42,7 +42,7 @@ runs:
     uses: cachix/cachix-action@v16
     with:
       name: ymeadows-build-tools
-      authToken: ${{inputs.cachix_auth_token }}
+      authToken: ${{inputs.cachix-auth-token }}
       extraPullNames: nix-community
 
   - name: Install tools

--- a/nix-shell-docker/action.yml
+++ b/nix-shell-docker/action.yml
@@ -4,6 +4,9 @@ inputs:
   tag-prefix:
     default: v
     description: Prefix used for the version
+  cachix-auth-token:
+    required: true
+    description: secrets.CACHIX_AUTH_TOKEN
 
 outputs:
   new-tag:
@@ -39,7 +42,7 @@ runs:
     uses: cachix/cachix-action@v16
     with:
       name: ymeadows-build-tools
-      authToken: ${{secrets.CACHIX_AUTH_TOKEN }}
+      authToken: ${{inputs.cachix_auth_token }}
       extraPullNames: nix-community
 
   - name: Install tools


### PR DESCRIPTION
- **fix(nix-shell-docker): Use an input, not a secret for CACHIX_AUTH_TOKEN**
- **fix(secrets): kebab case**

## Description of the change


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
