### PR TITLE
DOP-1727 Auth ignore temporary creds

### DIFF
--- a/lib/setup-gcr/action.yml
+++ b/lib/setup-gcr/action.yml
@@ -11,14 +11,20 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Authenticate with GCP
-    uses: google-github-actions/auth@v1
-    with:
-      workload_identity_provider: "projects/${{inputs.project_id_number}}/locations/global/workloadIdentityPools/github/providers/github-provider"
+    # assumes checkout already
+    - name: Ignore token files
+      shell: bash
+      run: |
+        echo "gha-creds-*.json" >> .gitignore
+        echo "gha-creds-*.json" >> .dockerignore
+    - name: Authenticate with GCP
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: "projects/${{inputs.project_id_number}}/locations/global/workloadIdentityPools/github/providers/github-provider"
       service_account: "github-actions@${{inputs.project}}.iam.gserviceaccount.com"
       token_format: access_token
-  - name: Setup Google Cloud
-    uses: google-github-actions/setup-gcloud@v1
-  - name: Setup Docker
-    shell: bash
-    run: gcloud auth configure-docker
+    - name: Setup Google Cloud
+      uses: google-github-actions/setup-gcloud@v1
+    - name: Setup Docker
+      shell: bash
+      run: gcloud auth configure-docker


### PR DESCRIPTION
## Description of the change

Prevent git, docker, nix, etc etc from unintentionally capturing and leaking
the GHA credentials created by google-github-actions/auth

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
