### PR TITLE
DOP-1742 Authenticate against the specifc registry

### DIFF
--- a/lib/setup-gcr/action.yml
+++ b/lib/setup-gcr/action.yml
@@ -8,6 +8,9 @@ inputs:
   project_id_number:
     description: The GCP project id to target
     required: true
+  registry:
+    description: The Artifact Registry to authenticate as
+    default: gcr.io
 runs:
   using: composite
   steps:
@@ -27,4 +30,4 @@ runs:
       uses: google-github-actions/setup-gcloud@v1
     - name: Setup Docker
       shell: bash
-      run: gcloud auth configure-docker
+      run: gcloud auth configure-docker ${{ inputs.registry }}

--- a/push-archive-to-registry/action.yml
+++ b/push-archive-to-registry/action.yml
@@ -41,11 +41,13 @@ runs:
       echo "MAJ=${{steps.cut-version.outputs.major}}" >> $GITHUB_ENV
       echo "MIN=${{steps.cut-version.outputs.major-minor}}" >> $GITHUB_ENV
       echo "IMAGE_NAME=docker://${{inputs.registry}}/$DOCKER_IMAGE_NAME" >> $GITHUB_ENV
+      echo "REGISTRY_NAME=$(echo ${{inputs.registry}} | sed 's#/.*##')" >> $GITHUB_ENV
 
   - uses: "ymeadows/github-actions-public/lib/setup-gcr@v0"
     with:
       project: ${{ inputs.project }}
       project_id_number: ${{ inputs.project_id_number }}
+      registry: ${{ env.REGISTRY_NAME }}
 
   - name: Push to QA
     shell: bash


### PR DESCRIPTION
This is necessary when pushing to an Artifact Registry (pkg.dev) instead of gcr.io

## Description of the change


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
