### PR TITLE
DOP-1745 Add summaries

### DIFF
--- a/push-archive-to-registry/action.yml
+++ b/push-archive-to-registry/action.yml
@@ -49,10 +49,14 @@ runs:
       project_id_number: ${{ inputs.project_id_number }}
       registry: ${{ env.REGISTRY_NAME }}
 
-  - name: Push to QA
+  - name: "Push to registry: ${{ env.REGISTRY_NAME }}"
     shell: bash
     run: |
       skopeo --insecure-policy copy docker-archive:${{inputs.archive_source}} ${IMAGE_NAME}:${{inputs.version-tag}}
+      echo ":ship: Pushed image: ${{ env.IMAGE_NAME }}:${{ inputs.version-tag }}" >> $GITHUB_STEP_SUMMARY
       skopeo --insecure-policy copy ${IMAGE_NAME}:${{inputs.version-tag}} ${IMAGE_NAME}:latest
+      echo ":ship: Tagged image: ${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
       skopeo --insecure-policy copy ${IMAGE_NAME}:${{inputs.version-tag}} ${IMAGE_NAME}:$MIN
+      echo ":ship: Pushed image: ${{ env.IMAGE_NAME }}:$MIN" >> $GITHUB_STEP_SUMMARY
       skopeo --insecure-policy copy ${IMAGE_NAME}:${{inputs.version-tag}} ${IMAGE_NAME}:$MAJ
+      echo ":ship: Pushed image: ${{ env.IMAGE_NAME }}:$MAJ" >> $GITHUB_STEP_SUMMARY

--- a/push-archive/action.yml
+++ b/push-archive/action.yml
@@ -14,42 +14,19 @@ inputs:
 runs:
   using: composite
   steps:
-  - id: cut-version
-    uses: ymeadows/github-actions-public/lib/rolling-versions@v0
+  - uses: ymeadows/github-actions-public/push-archive-to-registry@v0
     with:
-      version: ${{ inputs.version-tag }}
-      prefix: ${{ inputs.prefix }}
-
-  - name: Compute Docker Image Name
-    shell: bash
-    run: |
-      [ -z "$DOCKER_IMAGE_NAME" ] && DOCKER_IMAGE_NAME="${{ inputs.image-name }}"
-      [ -z "$DOCKER_IMAGE_NAME" ] && DOCKER_IMAGE_NAME=$(echo "${{ github.repository }}" | sed 's#${{ github.repository_owner }}/##')
-      echo "DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME" >> $GITHUB_ENV
-      echo "MAJ=${{steps.cut-version.outputs.major}}" >> $GITHUB_ENV
-      echo "MIN=${{steps.cut-version.outputs.major-minor}}" >> $GITHUB_ENV
-
-  - uses: "ymeadows/github-actions-public/lib/setup-gcr@v0"
-    with:
+      image-name: inputs.image-name
+      version-tag: inputs.version-tag
+      prefix: inputs.prefix
       project: t0-qa-282516
       project_id_number: "945001042473"
-
-  - name: Push to QA
-    shell: bash
-    run: |
-      skopeo --insecure-policy copy docker-archive:./result docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:${{inputs.version-tag}}
-      skopeo --insecure-policy copy docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:${{inputs.version-tag}} docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:latest
-      skopeo --insecure-policy copy docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:${{inputs.version-tag}} docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:$MIN
-      skopeo --insecure-policy copy docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:${{inputs.version-tag}} docker://gcr.io/t0-qa-282516/$DOCKER_IMAGE_NAME:$MAJ
-
-  - uses: ymeadows/github-actions-public/lib/setup-gcr@v0
+      registry: gcr.io/t0-qa-282516
+  - uses: ymeadows/github-actions-public/push-archive-to-registry@v0
     with:
+      image-name: inputs.image-name
+      version-tag: inputs.version-tag
+      prefix: inputs.prefix
       project: t0-prod
       project_id_number: "47742085387"
-  - name: Push to Prod
-    shell: bash
-    run: |
-      skopeo --insecure-policy copy docker-archive:./result docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:${{inputs.version-tag}}
-      skopeo --insecure-policy copy docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:${{inputs.version-tag}} docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:latest
-      skopeo --insecure-policy copy docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:${{inputs.version-tag}} docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:$MIN
-      skopeo --insecure-policy copy docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:${{inputs.version-tag}} docker://gcr.io/t0-prod/$DOCKER_IMAGE_NAME:$MAJ
+      registry: gcr.io/t0-prod

--- a/tag-next-version/action.yml
+++ b/tag-next-version/action.yml
@@ -62,7 +62,10 @@ runs:
     - run: |
         cd ${{ inputs.path }}
         git tag ${{ steps.inc-tag.outputs.result }}
+        echo ":flags: Tagging new   version: ${{ steps.inc.tag.outputs.result }}" >> $GITHUB_STEP_SUMMARY
         git tag -f ${{ steps.cut-version.outputs.major-minor }}
+        echo ":flags: Tagging minor version: ${{ steps.cut-version.outputs.major-minor }}" >> $GITHUB_STEP_SUMMARY
         git tag -f ${{ steps.cut-version.outputs.major }}
+        echo ":flags: Tagging major version: ${{ steps.cut-version.outputs.major }}" >> $GITHUB_STEP_SUMMARY
         git push -f --tags
       shell: bash


### PR DESCRIPTION
This commit adds step summaries to the `push-archive` and `tag-next-version` GitHub Actions.
These summaries will be displayed in the workflow run logs, providing a clearer overview of the actions performed.

Changes:
- Added step summaries for pushing images in `push-archive-to-registry/action.yml`.
- Added step summaries for tagging versions in `tag-next-version/action.yml`.

This will help users quickly understand what actions were taken during the workflow execution.

## Description of the change


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New action (non-breaking change that adds functionality)
- [ ] New feature for existing action (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Action has been run in a test workflow (repo: ?)

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ]  Reviewers requested
